### PR TITLE
Fix: Change service name

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 # handlers file for sa
 - name: Reload spamassassin
   systemd:
-    name: spamassassin
+    name: spamd
     state: reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Enable spamassassin
   systemd:
-    name: spamassassin
+    name: spamd
     state: started
     enabled: yes
   when:


### PR DESCRIPTION
Since bookworm, name of service has changed. spamd instead of spamassassin