### PR TITLE
Fix: Support spamd service name. Config file name changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,8 @@
 
 - name: Setup default file
   template:
-    src: spamassassin
-    dest: /etc/default/spamassassin
+    src: spamd
+    dest: /etc/default/spamd
     owner: root
     group: root
     mode: 0644

--- a/templates/spamd
+++ b/templates/spamd
@@ -1,13 +1,8 @@
-# /etc/default/spamassassin
+# /etc/default/spamd
 # Duncan Findlay
 
 # WARNING: please read README.spamd before using.
 # There may be security risks.
-
-# Prior to version 3.4.2-1, spamd could be enabled by setting
-# ENABLED=1 in this file. This is no longer supported. Instead, please
-# use the update-rc.d command, invoked for example as "update-rc.d
-# spamassassin enable", to enable the spamd service.
 
 # Options
 # See man spamd for possible options. The -d option is automatically added.
@@ -21,8 +16,8 @@ OPTIONS="--create-prefs -i 0.0.0.0 -A {{ sa__allowed_net }} --max-children 5 --h
 # Pid file
 # Where should spamd write its PID to file? If you use the -u or
 # --username option above, this needs to be writable by that user.
-# Otherwise, the init script will not be able to shut spamd down.
-PIDFILE="/var/run/spamd.pid"
+# Note that this setting is not used when spamd is managed by systemd
+PIDFILE="/run/spamd.pid"
 
 # Set nice level of spamd
 #NICE="--nicelevel 15"


### PR DESCRIPTION
The /etc/default/spamd file replace the old spamassassin one.